### PR TITLE
Reflections fix

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -459,7 +459,7 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
 
             #ifdef ${this._defineCubicName}
                 #ifdef ${this._defineLocalCubicName}
-                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName}, vec3(0, 0, 0), vec3(0, 0, 0), vec3(0, 0, 0), false);
+                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName}, vec3(0, 0, 0), vec3(0, 0, 0), vec3(0, 0, 0), 0);
                 #else
                 ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix});
                 #endif

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -58,8 +58,6 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
     /** @internal */
     public _reflectionPositionName: string;
     /** @internal */
-    public _reflectionOffsetName: string;
-    /** @internal */
     public _reflectionSizeName: string;
 
     protected _positionUVWName: string;
@@ -280,7 +278,6 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
         if ((<any>texture).boundingBoxSize) {
             const cubeTexture = <CubeTexture>texture;
             effect.setVector3(this._reflectionPositionName, cubeTexture.boundingBoxPosition);
-            effect.setVector3(this._reflectionOffsetName, cubeTexture.boundingBoxOffset);
             effect.setVector3(this._reflectionSizeName, cubeTexture.boundingBoxSize);
         }
     }
@@ -404,9 +401,6 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
         this._reflectionPositionName = state._getFreeVariableName("vReflectionPosition");
         state._emitUniformFromString(this._reflectionPositionName, NodeMaterialBlockConnectionPointTypes.Vector3);
 
-        this._reflectionOffsetName = state._getFreeVariableName("vReflectionOffset");
-        state._emitUniformFromString(this._reflectionOffsetName, NodeMaterialBlockConnectionPointTypes.Vector3);
-
         this._reflectionSizeName = state._getFreeVariableName("vReflectionSize");
         state._emitUniformFromString(this._reflectionSizeName, NodeMaterialBlockConnectionPointTypes.Vector3);
     }
@@ -464,7 +458,7 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
 
             #ifdef ${this._defineCubicName}
                 #ifdef ${this._defineLocalCubicName}
-                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName}, ${this._reflectionOffsetName});
+                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName});
                 #else
                 ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix});
                 #endif

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -435,6 +435,7 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
 
         worldNormalVarName += ".xyz";
 
+        //>> VRNET
         let code = `
             #ifdef ${this._defineMirroredEquirectangularFixedName}
                ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeMirroredFixedEquirectangularCoords(${worldPos}, ${worldNormalVarName}, ${direction});
@@ -475,6 +476,7 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
             #ifdef ${this._defineExplicitName}
                 ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = vec3(0, 0, 0);
             #endif\n`;
+        //<< VRNET
 
         if (!doNotEmitInvertZ) {
             code += `#ifdef ${this._defineOppositeZ}

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -458,7 +458,7 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
 
             #ifdef ${this._defineCubicName}
                 #ifdef ${this._defineLocalCubicName}
-                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName});
+                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName}, vec3(0, 0, 0), vec3(0, 0, 0), vec3(0, 0, 0), false);
                 #else
                 ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix});
                 #endif

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -435,7 +435,6 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
 
         worldNormalVarName += ".xyz";
 
-        //>> VRNET
         let code = `
             #ifdef ${this._defineMirroredEquirectangularFixedName}
                ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeMirroredFixedEquirectangularCoords(${worldPos}, ${worldNormalVarName}, ${direction});
@@ -458,8 +457,12 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
             #endif
 
             #ifdef ${this._defineCubicName}
-                #ifdef ${this._defineLocalCubicName}
-                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName}, vec3(0, 0, 0), vec3(0, 0, 0), vec3(0, 0, 0), false);
+                #ifdef ${this._defineLocalCubicName}`;
+        //>> VRNET
+        code += `
+                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName}, vec3(0, 0, 0), vec3(0, 0, 0), vec3(0, 0, 0), false);`;
+        //<< VRNET
+        code += `
                 #else
                 ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix});
                 #endif
@@ -476,7 +479,6 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
             #ifdef ${this._defineExplicitName}
                 ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = vec3(0, 0, 0);
             #endif\n`;
-        //<< VRNET
 
         if (!doNotEmitInvertZ) {
             code += `#ifdef ${this._defineOppositeZ}

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -459,7 +459,7 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
 
             #ifdef ${this._defineCubicName}
                 #ifdef ${this._defineLocalCubicName}
-                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName}, vec3(0, 0, 0), vec3(0, 0, 0), vec3(0, 0, 0), 0);
+                    ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicLocalCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix}, ${this._reflectionSizeName}, ${this._reflectionPositionName}, vec3(0, 0, 0), vec3(0, 0, 0), vec3(0, 0, 0), false);
                 #else
                 ${state._declareLocalVar(this._reflectionVectorName, NodeMaterialBlockConnectionPointTypes.Vector3)} = computeCubicCoords(${worldPos}, ${worldNormalVarName}, ${vEyePosition}.xyz, ${reflectionMatrix});
                 #endif

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1496,7 +1496,11 @@ export abstract class PBRBaseMaterial extends PushMaterial {
             "vOpacityInfos",
             "vReflectionInfos",
             "vReflectionPosition",
+            //>> VRNET
             "vReflectionOffset",
+            "vBoundingBoxMax",
+            "vBoundingBoxMin",
+            //<< VRNET
             "vReflectionSize",
             "vEmissiveInfos",
             "vReflectivityInfos",
@@ -2104,7 +2108,11 @@ export abstract class PBRBaseMaterial extends PushMaterial {
         ubo.addUniform("vReflectionInfos", 2);
         ubo.addUniform("vReflectionFilteringInfo", 2);
         ubo.addUniform("vReflectionPosition", 3);
+        //>> VRNET
         ubo.addUniform("vReflectionOffset", 3);
+        ubo.addUniform("vBoundingBoxMax", 3);
+        ubo.addUniform("vBoundingBoxMin", 3);
+        //<< VRNET
         ubo.addUniform("vReflectionSize", 3);
         ubo.addUniform("vBumpInfos", 3);
         ubo.addUniform("albedoMatrix", 16);
@@ -2261,7 +2269,11 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                             const cubeTexture = <CubeTexture>reflectionTexture;
 
                             ubo.updateVector3("vReflectionPosition", cubeTexture.boundingBoxPosition);
+                            //>> VRNET
                             ubo.updateVector3("vReflectionOffset", cubeTexture.boundingBoxOffset);
+                            ubo.updateVector3("vBoundingBoxMax", mesh.getBoundingInfo().boundingBox.maximumWorld);
+                            ubo.updateVector3("vBoundingBoxMin", mesh.getBoundingInfo().boundingBox.minimumWorld);
+                            //<< VRNET
                             ubo.updateVector3("vReflectionSize", cubeTexture.boundingBoxSize);
                         }
 

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1413,8 +1413,12 @@ export class StandardMaterial extends PushMaterial {
                 "refractionLeftColor",
                 "refractionRightColor",
                 "vReflectionPosition",
-                "vReflectionSize",
+                //>> VRNET
                 "vReflectionOffset",
+                "vBoundingBoxMax",
+                "vBoundingBoxMin",
+                //<< VRNET
+                "vReflectionSize",
                 "vRefractionPosition",
                 "vRefractionSize",
                 "logarithmicDepthConstant",
@@ -1583,7 +1587,11 @@ export class StandardMaterial extends PushMaterial {
         ubo.addUniform("vOpacityInfos", 2);
         ubo.addUniform("vReflectionInfos", 2);
         ubo.addUniform("vReflectionPosition", 3);
+        //>> VRNET
         ubo.addUniform("vReflectionOffset", 3);
+        ubo.addUniform("vBoundingBoxMax", 3);
+        ubo.addUniform("vBoundingBoxMin", 3);
+        //<< VRNET
         ubo.addUniform("vReflectionSize", 3);
         ubo.addUniform("vEmissiveInfos", 2);
         ubo.addUniform("vLightmapInfos", 2);
@@ -1725,7 +1733,11 @@ export class StandardMaterial extends PushMaterial {
                             const cubeTexture = <CubeTexture>this._reflectionTexture;
 
                             ubo.updateVector3("vReflectionPosition", cubeTexture.boundingBoxPosition);
+                            //>> VRNET
                             ubo.updateVector3("vReflectionOffset", cubeTexture.boundingBoxOffset);
+                            ubo.updateVector3("vBoundingBoxMax", mesh.getBoundingInfo().boundingBox.maximumWorld);
+                            ubo.updateVector3("vBoundingBoxMin", mesh.getBoundingInfo().boundingBox.minimumWorld);
+                            //<< VRNET
                             ubo.updateVector3("vReflectionSize", cubeTexture.boundingBoxSize);
                         }
                     } else {

--- a/packages/dev/core/src/PostProcesses/thinSSRPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSRPostProcess.ts
@@ -37,9 +37,6 @@ export class ThinSSRPostProcess extends EffectWrapper {
         "maxDistance",
         "selfCollisionNumSkip",
         "vReflectionPosition",
-        //>> VRNET
-        "vReflectionOffset",
-        //<< VRNET
         "vReflectionSize",
         "backSizeFactor",
         "reflectivityThreshold",
@@ -444,9 +441,6 @@ export class ThinSSRPostProcess extends EffectWrapper {
 
             if (this._environmentTexture.boundingBoxSize) {
                 effect.setVector3("vReflectionPosition", this._environmentTexture.boundingBoxPosition);
-                //>> VRNET
-                effect.setVector3("vReflectionOffset", this._environmentTexture.boundingBoxOffset);
-                //<< VRNET
                 effect.setVector3("vReflectionSize", this._environmentTexture.boundingBoxSize);
             }
         }

--- a/packages/dev/core/src/Shaders/ShadersInclude/defaultFragmentDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/defaultFragmentDeclaration.fx
@@ -87,7 +87,11 @@ uniform vec4 emissiveRightColor;
     #ifndef REFLECTIONMAP_SKYBOX
         #if defined(USE_LOCAL_REFLECTIONMAP_CUBIC) && defined(REFLECTIONMAP_CUBIC)
             uniform vec3 vReflectionPosition;
+            //>> VRNET
             uniform vec3 vReflectionOffset;
+            uniform vec3 vBoundinxBoxMax;
+            uniform vec3 vBoundinxBoxMin;
+            //<< VRNET
             uniform vec3 vReflectionSize; 
         #endif
     #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/defaultUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/defaultUboDeclaration.fx
@@ -16,7 +16,11 @@ uniform Material
 	vec2 vOpacityInfos;
 	vec2 vReflectionInfos;
 	vec3 vReflectionPosition;
+	//>> VRNET
 	vec3 vReflectionOffset;
+	vec3 vBoundinxBoxMax;
+	vec3 vBoundinxBoxMin;
+	//<< VRNET
 	vec3 vReflectionSize;
 	vec2 vEmissiveInfos;
 	vec2 vLightmapInfos;

--- a/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
@@ -201,30 +201,30 @@ vec3 fromRGBD(vec4 rgbd) {
     return rgbd.rgb / rgbd.a;
 }
 
-vec3 parallaxCorrectNormal( vec3 vertexPos, vec3 origVec, vec3 cubeSize, vec3 cubePos ) {
+//>> VRNET
+vec3 parallaxCorrectNormal(
+    vec3 vertexPos,
+    vec3 origVec, 
+    vec3 cubeSize, 
+    vec3 cubePos, 
+    vec3 cubeOffset, 
+    vec3 boundingBoxMax, 
+    vec3 boundingBoxMin, 
+    bool useBoundingBox
+) 
+{
 	// Find the ray intersection with box plane
 	vec3 invOrigVec = vec3(1.) / origVec;
 	vec3 halfSize = cubeSize * 0.5;
-	vec3 intersecAtMaxPlane = (cubePos + halfSize - vertexPos) * invOrigVec;
-	vec3 intersecAtMinPlane = (cubePos - halfSize - vertexPos) * invOrigVec;
-	// Get the largest intersection values (we are not intersted in negative values)
-	vec3 largestIntersec = max(intersecAtMaxPlane, intersecAtMinPlane);
-	// Get the closest of all solutions
-	float distance = min(min(largestIntersec.x, largestIntersec.y), largestIntersec.z);
-	// Get the intersection position
-	vec3 intersectPositionWS = vertexPos + origVec * distance;
-	// Get corrected vector
-	return intersectPositionWS - cubePos;
-}
-
-//>> VRNET
-// same as parallaxCorrectNormal, but with reflection probe offset and mesh's bounding box for correction
-vec3 boundingBasedParallaxCorrectNormal( vec3 vertexPos, vec3 origVec, vec3 cubeSize, vec3 cubePos, vec3 cubeOffset, vec3 boundingBoxMax, vec3 boundingBoxMin ) {
-	// Find the ray intersection with box plane
-	vec3 invOrigVec = 1.0 / (origVec + sign(origVec) * Epsilon);
-	vec3 halfSize = cubeSize * 0.5;
-	vec3 intersecAtMaxPlane = (max(cubePos + cubeOffset + halfSize, boundingBoxMax) - vertexPos) * invOrigVec;
-	vec3 intersecAtMinPlane = (min(cubePos + cubeOffset - halfSize, boundingBoxMin) - vertexPos) * invOrigVec;
+    
+    vec3 maxBounds = cubePos + cubeOffset + halfSize;
+    vec3 minBounds = cubePos + cubeOffset - halfSize;
+    if (useBoundingBox) {
+        maxBounds = max(maxBounds, boundingBoxMax);
+        minBounds = min(minBounds, boundingBoxMin);
+    }
+    vec3 intersecAtMaxPlane = (maxBounds - vertexPos) * invOrigVec;
+    vec3 intersecAtMinPlane = (minBounds - vertexPos) * invOrigVec;
 	// Get the largest intersection values (we are not intersted in negative values)
 	vec3 largestIntersec = max(intersecAtMaxPlane, intersecAtMinPlane);
 	// Get the closest of all solutions

--- a/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
@@ -210,7 +210,7 @@ vec3 parallaxCorrectNormal(
     vec3 cubeOffset, 
     vec3 boundingBoxMax, 
     vec3 boundingBoxMin, 
-    float useBoundingBox
+    bool useBoundingBox
 ) 
 {
 	// Find the ray intersection with box plane
@@ -219,8 +219,10 @@ vec3 parallaxCorrectNormal(
     
     vec3 maxBounds = cubePos + cubeOffset + halfSize;
     vec3 minBounds = cubePos + cubeOffset - halfSize;
-    maxBounds = mix(maxBounds, max(maxBounds, boundingBoxMax), useBoundingBox);
-    minBounds = mix(minBounds, min(minBounds, boundingBoxMin), useBoundingBox);
+    if (useBoundingBox) {
+        maxBounds = max(maxBounds, boundingBoxMax);
+        minBounds = min(minBounds, boundingBoxMin);
+    }
     vec3 intersecAtMaxPlane = (maxBounds - vertexPos) * invOrigVec;
     vec3 intersecAtMinPlane = (minBounds - vertexPos) * invOrigVec;
 	// Get the largest intersection values (we are not intersted in negative values)

--- a/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
@@ -210,7 +210,7 @@ vec3 parallaxCorrectNormal(
     vec3 cubeOffset, 
     vec3 boundingBoxMax, 
     vec3 boundingBoxMin, 
-    bool useBoundingBox
+    float useBoundingBox
 ) 
 {
 	// Find the ray intersection with box plane
@@ -219,10 +219,8 @@ vec3 parallaxCorrectNormal(
     
     vec3 maxBounds = cubePos + cubeOffset + halfSize;
     vec3 minBounds = cubePos + cubeOffset - halfSize;
-    if (useBoundingBox) {
-        maxBounds = max(maxBounds, boundingBoxMax);
-        minBounds = min(minBounds, boundingBoxMin);
-    }
+    maxBounds = mix(maxBounds, max(maxBounds, boundingBoxMax), useBoundingBox);
+    minBounds = mix(minBounds, min(minBounds, boundingBoxMin), useBoundingBox);
     vec3 intersecAtMaxPlane = (maxBounds - vertexPos) * invOrigVec;
     vec3 intersecAtMinPlane = (minBounds - vertexPos) * invOrigVec;
 	// Get the largest intersection values (we are not intersted in negative values)

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
@@ -82,7 +82,7 @@ struct subSurfaceOutParams
             #ifdef SS_REFRACTIONMAP_3D
                 #ifdef SS_USE_LOCAL_REFRACTIONMAP_CUBIC
                     //>> VRNET
-                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3(0.), vec3(0.), vec3(0.), false);
+                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3(0.), vec3(0.), vec3(0.), 0.);
                     //<< VRNET
                 #endif
                 refractionVector.y = refractionVector.y * vRefractionInfos.w;

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
@@ -82,7 +82,7 @@ struct subSurfaceOutParams
             #ifdef SS_REFRACTIONMAP_3D
                 #ifdef SS_USE_LOCAL_REFRACTIONMAP_CUBIC
                     //>> VRNET
-                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3(0.), vec3(0.), vec3(0.), 0.);
+                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3(0.), vec3(0.), vec3(0.), false);
                     //<< VRNET
                 #endif
                 refractionVector.y = refractionVector.y * vRefractionInfos.w;

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
@@ -81,7 +81,9 @@ struct subSurfaceOutParams
             // _____________________________ 2D vs 3D Maps ________________________________
             #ifdef SS_REFRACTIONMAP_3D
                 #ifdef SS_USE_LOCAL_REFRACTIONMAP_CUBIC
-                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition);
+                    //>> VRNET
+                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3(0.), vec3(0.), vec3(0.), false);
+                    //<< VRNET
                 #endif
                 refractionVector.y = refractionVector.y * vRefractionInfos.w;
                 vec3 refractionCoords = refractionVector;

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrFragmentDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrFragmentDeclaration.fx
@@ -78,7 +78,11 @@ uniform mat4 view;
 
     #if defined(USE_LOCAL_REFLECTIONMAP_CUBIC) && defined(REFLECTIONMAP_CUBIC)
 	    uniform vec3 vReflectionPosition;
+        //>> VRNET
         uniform vec3 vReflectionOffset;
+        uniform vec3 vBoundingBoxMax;
+        uniform vec3 vBoundingBoxMin;
+        //<< VRNET
 	    uniform vec3 vReflectionSize;
     #endif
 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrUboDeclaration.fx
@@ -35,7 +35,11 @@ uniform Material {
     vec2 vReflectionInfos;
     vec2 vReflectionFilteringInfo;
     vec3 vReflectionPosition;
+    //>> VRNET
     vec3 vReflectionOffset;
+    vec3 vBoundingBoxMax;
+    vec3 vBoundingBoxMin;
+    //<< VRNET
     vec3 vReflectionSize;
     vec3 vBumpInfos;
     mat4 albedoMatrix;

--- a/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
@@ -72,33 +72,15 @@ vec3 computeCubicCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 
     return coords;
 }
 
-vec3 computeCubicLocalCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition)
-{
-    vec3 viewDir = normalize(worldPos.xyz - eyePosition);
-
-    // worldNormal has already been normalized.
-    vec3 coords = reflect(viewDir, worldNormal);
-
-	coords = parallaxCorrectNormal(worldPos.xyz, coords, reflectionSize, reflectionPosition);
-
-    coords = vec3(reflectionMatrix * vec4(coords, 0));
-
-    #ifdef INVERTCUBICMAP
-        coords.y *= -1.0;
-    #endif
-
-    return coords;
-}
-
 //>> VRNET
-vec3 computeBoundingBasedCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition, vec3 reflectionOffset, vec3 boundingBoxMax, vec3 boundingBoxMin)
+vec3 computeCubicLocalCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition, vec3 reflectionOffset, vec3 boundingBoxMax, vec3 boundingBoxMin, bool useBoundingBox)
 {
     vec3 viewDir = normalize(worldPos.xyz - eyePosition);
 
     // worldNormal has already been normalized.
     vec3 coords = reflect(viewDir, worldNormal);
 
-	coords = boundingBasedParallaxCorrectNormal(worldPos.xyz, coords, reflectionSize, reflectionPosition, reflectionOffset, boundingBoxMax, boundingBoxMin);
+	coords = parallaxCorrectNormal(worldPos.xyz, coords, reflectionSize, reflectionPosition, reflectionOffset, boundingBoxMax, boundingBoxMin, useBoundingBox);
 
     coords = vec3(reflectionMatrix * vec4(coords, 0));
 
@@ -148,7 +130,7 @@ vec3 computeReflectionCoords(vec4 worldPos, vec3 worldNormal)
 #ifdef REFLECTIONMAP_CUBIC
 	#ifdef USE_LOCAL_REFLECTIONMAP_CUBIC
 		//>> VRNET
-    	return computeBoundingBasedCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix, vReflectionSize, vReflectionPosition, vReflectionOffset, vBoundingBoxMax, vBoundingBoxMin);
+    	return computeCubicLocalCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix, vReflectionSize, vReflectionPosition, vReflectionOffset, vBoundingBoxMax, vBoundingBoxMin, true);
 		//<< VRNET
 	#else
     	return computeCubicCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix);

--- a/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
@@ -73,7 +73,7 @@ vec3 computeCubicCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 
 }
 
 //>> VRNET
-vec3 computeCubicLocalCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition, vec3 reflectionOffset, vec3 boundingBoxMax, vec3 boundingBoxMin, bool useBoundingBox)
+vec3 computeCubicLocalCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition, vec3 reflectionOffset, vec3 boundingBoxMax, vec3 boundingBoxMin, float useBoundingBox)
 {
     vec3 viewDir = normalize(worldPos.xyz - eyePosition);
 
@@ -130,7 +130,7 @@ vec3 computeReflectionCoords(vec4 worldPos, vec3 worldNormal)
 #ifdef REFLECTIONMAP_CUBIC
 	#ifdef USE_LOCAL_REFLECTIONMAP_CUBIC
 		//>> VRNET
-    	return computeCubicLocalCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix, vReflectionSize, vReflectionPosition, vReflectionOffset, vBoundingBoxMax, vBoundingBoxMin, true);
+    	return computeCubicLocalCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix, vReflectionSize, vReflectionPosition, vReflectionOffset, vBoundingBoxMax, vBoundingBoxMin, 1.0);
 		//<< VRNET
 	#else
     	return computeCubicCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix);

--- a/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
@@ -72,14 +72,14 @@ vec3 computeCubicCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 
     return coords;
 }
 
-vec3 computeCubicLocalCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition, vec3 reflectionOffset)
+vec3 computeCubicLocalCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition)
 {
     vec3 viewDir = normalize(worldPos.xyz - eyePosition);
 
     // worldNormal has already been normalized.
     vec3 coords = reflect(viewDir, worldNormal);
 
-	coords = parallaxCorrectNormal(worldPos.xyz, coords, reflectionSize, reflectionPosition + reflectionOffset) + reflectionOffset;
+	coords = parallaxCorrectNormal(worldPos.xyz, coords, reflectionSize, reflectionPosition);
 
     coords = vec3(reflectionMatrix * vec4(coords, 0));
 
@@ -89,6 +89,26 @@ vec3 computeCubicLocalCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, 
 
     return coords;
 }
+
+//>> VRNET
+vec3 computeBoundingBasedCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition, vec3 reflectionOffset, vec3 boundingBoxMax, vec3 boundingBoxMin)
+{
+    vec3 viewDir = normalize(worldPos.xyz - eyePosition);
+
+    // worldNormal has already been normalized.
+    vec3 coords = reflect(viewDir, worldNormal);
+
+	coords = boundingBasedReflection(worldPos.xyz, coords, reflectionSize, reflectionPosition, reflectionOffset, eyePosition, boundingBoxMax, boundingBoxMin);
+
+    coords = vec3(reflectionMatrix * vec4(coords, 0));
+
+    #ifdef INVERTCUBICMAP
+        coords.y *= -1.0;
+    #endif
+
+    return coords;
+}
+//<< VRNET
 
 vec3 computeProjectionCoords(vec4 worldPos, mat4 view, mat4 reflectionMatrix)
 {
@@ -127,7 +147,9 @@ vec3 computeReflectionCoords(vec4 worldPos, vec3 worldNormal)
 
 #ifdef REFLECTIONMAP_CUBIC
 	#ifdef USE_LOCAL_REFLECTIONMAP_CUBIC
-    	return computeCubicLocalCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix, vReflectionSize, vReflectionPosition, vReflectionOffset);
+		//>> VRNET
+    	return computeBoundingBasedCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix, vReflectionSize, vReflectionPosition, vReflectionOffset, vBoundingBoxMax, vBoundingBoxMin);
+		//<< VRNET
 	#else
     	return computeCubicCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix);
 	#endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
@@ -98,7 +98,7 @@ vec3 computeBoundingBasedCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePositio
     // worldNormal has already been normalized.
     vec3 coords = reflect(viewDir, worldNormal);
 
-	coords = boundingBasedReflection(worldPos.xyz, coords, reflectionSize, reflectionPosition, reflectionOffset, eyePosition, boundingBoxMax, boundingBoxMin);
+	coords = boundingBasedParallaxCorrectNormal(worldPos.xyz, coords, reflectionSize, reflectionPosition, reflectionOffset, boundingBoxMax, boundingBoxMin);
 
     coords = vec3(reflectionMatrix * vec4(coords, 0));
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/reflectionFunction.fx
@@ -73,7 +73,7 @@ vec3 computeCubicCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 
 }
 
 //>> VRNET
-vec3 computeCubicLocalCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition, vec3 reflectionOffset, vec3 boundingBoxMax, vec3 boundingBoxMin, float useBoundingBox)
+vec3 computeCubicLocalCoords(vec4 worldPos, vec3 worldNormal, vec3 eyePosition, mat4 reflectionMatrix, vec3 reflectionSize, vec3 reflectionPosition, vec3 reflectionOffset, vec3 boundingBoxMax, vec3 boundingBoxMin, bool useBoundingBox)
 {
     vec3 viewDir = normalize(worldPos.xyz - eyePosition);
 
@@ -130,7 +130,7 @@ vec3 computeReflectionCoords(vec4 worldPos, vec3 worldNormal)
 #ifdef REFLECTIONMAP_CUBIC
 	#ifdef USE_LOCAL_REFLECTIONMAP_CUBIC
 		//>> VRNET
-    	return computeCubicLocalCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix, vReflectionSize, vReflectionPosition, vReflectionOffset, vBoundingBoxMax, vBoundingBoxMin, 1.0);
+    	return computeCubicLocalCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix, vReflectionSize, vReflectionPosition, vReflectionOffset, vBoundingBoxMax, vBoundingBoxMin, true);
 		//<< VRNET
 	#else
     	return computeCubicCoords(worldPos, worldNormal, vEyePosition.xyz, reflectionMatrix);

--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -217,7 +217,9 @@ void main(void) {
 	vec3 refractionVector = normalize(refract(-viewDirectionW, normalW, vRefractionInfos.y));
 	#ifdef REFRACTIONMAP_3D
         #ifdef USE_LOCAL_REFRACTIONMAP_CUBIC
-            refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, vRefractionSize, vRefractionPosition);
+			//>> VRNET
+            refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, vRefractionSize, vRefractionPosition, vec3(0.), vec3(0.), vec3(0.), false);
+			//<< VRNET
         #endif
 		refractionVector.y = refractionVector.y * vRefractionInfos.w;
 

--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -218,7 +218,7 @@ void main(void) {
 	#ifdef REFRACTIONMAP_3D
         #ifdef USE_LOCAL_REFRACTIONMAP_CUBIC
 			//>> VRNET
-            refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, vRefractionSize, vRefractionPosition, vec3(0.), vec3(0.), vec3(0.), 0.);
+            refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, vRefractionSize, vRefractionPosition, vec3(0.), vec3(0.), vec3(0.), false);
 			//<< VRNET
         #endif
 		refractionVector.y = refractionVector.y * vRefractionInfos.w;

--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -218,7 +218,7 @@ void main(void) {
 	#ifdef REFRACTIONMAP_3D
         #ifdef USE_LOCAL_REFRACTIONMAP_CUBIC
 			//>> VRNET
-            refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, vRefractionSize, vRefractionPosition, vec3(0.), vec3(0.), vec3(0.), false);
+            refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, vRefractionSize, vRefractionPosition, vec3(0.), vec3(0.), vec3(0.), 0.);
 			//<< VRNET
         #endif
 		refractionVector.y = refractionVector.y * vRefractionInfos.w;

--- a/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
+++ b/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
@@ -148,7 +148,7 @@ void main()
     #ifdef SSR_USE_LOCAL_REFLECTIONMAP_CUBIC
         vec4 worldPos = invView * vec4(csPosition, 1.0);
         //>> VRNET
-	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), vReflectionSize, vReflectionPosition, vec3(0.), vec3(0.), vec3(0.), 0.);
+	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), vReflectionSize, vReflectionPosition, vec3(0.), vec3(0.), vec3(0.), false);
         //<< VRNET
     #endif
     #ifdef SSR_INVERTCUBICMAP

--- a/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
+++ b/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
@@ -147,7 +147,9 @@ void main()
     vec3 wReflectedVector = vec3(invView * vec4(csReflectedVector, 0.0));
     #ifdef SSR_USE_LOCAL_REFLECTIONMAP_CUBIC
         vec4 worldPos = invView * vec4(csPosition, 1.0);
-	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), vReflectionSize, vReflectionPosition);
+        //>> VRNET
+	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), vReflectionSize, vReflectionPosition, vec3(0.), vec3(0.), vec3(0.), false);
+        //<< VRNET
     #endif
     #ifdef SSR_INVERTCUBICMAP
         wReflectedVector.y *= -1.0;

--- a/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
+++ b/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
@@ -148,7 +148,7 @@ void main()
     #ifdef SSR_USE_LOCAL_REFLECTIONMAP_CUBIC
         vec4 worldPos = invView * vec4(csPosition, 1.0);
         //>> VRNET
-	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), vReflectionSize, vReflectionPosition, vec3(0.), vec3(0.), vec3(0.), false);
+	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), vReflectionSize, vReflectionPosition, vec3(0.), vec3(0.), vec3(0.), 0.);
         //<< VRNET
     #endif
     #ifdef SSR_INVERTCUBICMAP

--- a/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
+++ b/packages/dev/core/src/Shaders/screenSpaceReflection2.fragment.fx
@@ -28,7 +28,6 @@ uniform sampler2D depthSampler;
     uniform samplerCube envCubeSampler;
     #ifdef SSR_USE_LOCAL_REFLECTIONMAP_CUBIC
         uniform vec3 vReflectionPosition;
-        uniform vec3 vReflectionOffset;
         uniform vec3 vReflectionSize;
     #endif
 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/defaultUboDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/defaultUboDeclaration.fx
@@ -12,6 +12,11 @@ uniform vAmbientInfos: vec2f;
 uniform vOpacityInfos: vec2f;
 uniform vReflectionInfos: vec2f;
 uniform vReflectionPosition: vec3f;
+//>> VRNET
+uniform vReflectionOffset: vec3f;
+uniform vBoundingBoxMax: vec3f;
+uniform vBoundingBoxMin: vec3f;
+//<< VRNET
 uniform vReflectionSize: vec3f;
 uniform vEmissiveInfos: vec2f;
 uniform vLightmapInfos: vec2f;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/helperFunctions.fx
@@ -204,18 +204,15 @@ fn parallaxCorrectNormal(
     cubeOffset: vec3f, 
     boundingBoxMax: vec3f, 
     boundingBoxMin: vec3f, 
-    useBoundingBox: bool
+    useBoundingBox: float
 ) -> vec3f  {
 	// Find the ray intersection with box plane
 	let invOrigVec: vec3f = vec3f(1.) / origVec;
 	let halfSize: vec3f = cubeSize * 0.5;
     let maxBound: vec3f = cubePos + cubeOffset + halfSize;
     let minBound: vec3f = cubePos + cubeOffset - halfSize;
-    if (useBoundingBox) {
-        // Use bounding box for intersection
-        maxBound = max(maxBound, boundingBoxMax);
-        minBound = min(minBound, boundingBoxMin);
-    }
+    maxBound = mix(maxBound, max(maxBound, boundingBoxMax), useBoundingBox);
+    minBound = mix(minBound, min(minBound, boundingBoxMin), useBoundingBox);
     // Get the intersection values at the max and min planes
 	let intersecAtMaxPlane: vec3f = (maxBound - vertexPos) * invOrigVec;
 	let intersecAtMinPlane: vec3f = (minBound - vertexPos) * invOrigVec;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/helperFunctions.fx
@@ -204,15 +204,18 @@ fn parallaxCorrectNormal(
     cubeOffset: vec3f, 
     boundingBoxMax: vec3f, 
     boundingBoxMin: vec3f, 
-    useBoundingBox: float
+    useBoundingBox: bool
 ) -> vec3f  {
 	// Find the ray intersection with box plane
 	let invOrigVec: vec3f = vec3f(1.) / origVec;
 	let halfSize: vec3f = cubeSize * 0.5;
     let maxBound: vec3f = cubePos + cubeOffset + halfSize;
     let minBound: vec3f = cubePos + cubeOffset - halfSize;
-    maxBound = mix(maxBound, max(maxBound, boundingBoxMax), useBoundingBox);
-    minBound = mix(minBound, min(minBound, boundingBoxMin), useBoundingBox);
+    if (useBoundingBox) {
+        // Use bounding box for intersection
+        maxBound = max(maxBound, boundingBoxMax);
+        minBound = min(minBound, boundingBoxMin);
+    }
     // Get the intersection values at the max and min planes
 	let intersecAtMaxPlane: vec3f = (maxBound - vertexPos) * invOrigVec;
 	let intersecAtMinPlane: vec3f = (minBound - vertexPos) * invOrigVec;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/helperFunctions.fx
@@ -195,30 +195,30 @@ fn fromRGBD(rgbd: vec4<f32>) -> vec3f {
     return rgb / rgbd.a;
 }
 
-fn parallaxCorrectNormal(vertexPos: vec3f, origVec: vec3f, cubeSize: vec3f, cubePos: vec3f) -> vec3f  {
-	// Find the ray intersection with box plane
-	let invOrigVec: vec3f = vec3f(1.) / origVec;
-	let halfSize: vec3f = cubeSize * 0.5;
-	let intersecAtMaxPlane: vec3f = (cubePos + halfSize - vertexPos) * invOrigVec;
-	let intersecAtMinPlane: vec3f = (cubePos - halfSize - vertexPos) * invOrigVec;
-	// Get the largest intersection values (we are not intersted in negative values)
-	let largestIntersec: vec3f = max(intersecAtMaxPlane, intersecAtMinPlane);
-	// Get the closest of all solutions
-	let distance: f32 = min(min(largestIntersec.x, largestIntersec.y), largestIntersec.z);
-	// Get the intersection position
-	let intersectPositionWS: vec3f = vertexPos + origVec * distance;
-	// Get corrected vector
-	return intersectPositionWS - cubePos;
-}
-
 //>> VRNET
-// same as parallaxCorrectNormal, but with reflection probe offset and mesh's bounding box for correction
-fn boundingBasedParallaxCorrectNormal(vertexPos: vec3f, origVec: vec3f, cubeSize: vec3f, cubePos: vec3f, , cubeOffset: vec3f, eyePosition: vec3f, boundingBoxMax: vec3f, boundingBoxMin: vec3f) -> vec3f  {
+fn parallaxCorrectNormal(
+    vertexPos: vec3f,
+    origVec: vec3f, 
+    cubeSize: vec3f, 
+    cubePos: vec3f, 
+    cubeOffset: vec3f, 
+    boundingBoxMax: vec3f, 
+    boundingBoxMin: vec3f, 
+    useBoundingBox: bool
+) -> vec3f  {
 	// Find the ray intersection with box plane
 	let invOrigVec: vec3f = vec3f(1.) / origVec;
 	let halfSize: vec3f = cubeSize * 0.5;
-	let intersecAtMaxPlane: vec3f = (max(cubePos + cubeOffset + halfSize) - vertexPos) * invOrigVec;
-	let intersecAtMinPlane: vec3f = (min(cubePos + cubeOffset - halfSize) - vertexPos) * invOrigVec;
+    let maxBound: vec3f = cubePos + cubeOffset + halfSize;
+    let minBound: vec3f = cubePos + cubeOffset - halfSize;
+    if (useBoundingBox) {
+        // Use bounding box for intersection
+        maxBound = max(maxBound, boundingBoxMax);
+        minBound = min(minBound, boundingBoxMin);
+    }
+    // Get the intersection values at the max and min planes
+	let intersecAtMaxPlane: vec3f = (maxBound - vertexPos) * invOrigVec;
+	let intersecAtMinPlane: vec3f = (minBound - vertexPos) * invOrigVec;
 	// Get the largest intersection values (we are not intersted in negative values)
 	let largestIntersec: vec3f = max(intersecAtMaxPlane, intersecAtMinPlane);
 	// Get the closest of all solutions

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockSubSurface.fx
@@ -87,7 +87,7 @@ struct subSurfaceOutParams
             #ifdef SS_REFRACTIONMAP_3D
                 #ifdef SS_USE_LOCAL_REFRACTIONMAP_CUBIC
                     //>> VRNET
-                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), 0.);
+                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), false);
                     //<< VRNET
                 #endif
                 refractionVector.y = refractionVector.y * vRefractionInfos.w;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockSubSurface.fx
@@ -87,7 +87,7 @@ struct subSurfaceOutParams
             #ifdef SS_REFRACTIONMAP_3D
                 #ifdef SS_USE_LOCAL_REFRACTIONMAP_CUBIC
                     //>> VRNET
-                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), false);
+                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), 0.);
                     //<< VRNET
                 #endif
                 refractionVector.y = refractionVector.y * vRefractionInfos.w;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockSubSurface.fx
@@ -86,7 +86,9 @@ struct subSurfaceOutParams
             // _____________________________ 2D vs 3D Maps ________________________________
             #ifdef SS_REFRACTIONMAP_3D
                 #ifdef SS_USE_LOCAL_REFRACTIONMAP_CUBIC
-                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition);
+                    //>> VRNET
+                    refractionVector = parallaxCorrectNormal(vPositionW, refractionVector, refractionSize, refractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), false);
+                    //<< VRNET
                 #endif
                 refractionVector.y = refractionVector.y * vRefractionInfos.w;
                 var refractionCoords: vec3f = refractionVector;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrUboDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrUboDeclaration.fx
@@ -10,6 +10,11 @@ uniform vMicroSurfaceSamplerInfos: vec2f;
 uniform vReflectionInfos: vec2f;
 uniform vReflectionFilteringInfo: vec2f;
 uniform vReflectionPosition: vec3f;
+//>> VRNET
+uniform vReflectionOffset: vec3f;
+uniform vBoundingBoxMax: vec3f;
+uniform vBoundingBoxMin: vec3f;
+//<< VRNET
 uniform vReflectionSize: vec3f;
 uniform vBumpInfos: vec3f;
 uniform albedoMatrix: mat4x4f;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
@@ -83,7 +83,7 @@ fn computeCubicLocalCoords(
 	reflectionOffset: vec3f, 
 	boundingBoxMax: vec3f, 
 	boundingBoxMin: vec3f, 
-	useBoundingBox: bool
+	useBoundingBox: float
 ) -> vec3f
 {
     var viewDir: vec3f = normalize(worldPos.xyz - eyePosition);
@@ -150,7 +150,7 @@ fn computeReflectionCoords(worldPos: vec4f, worldNormal: vec3f) -> vec3f
 #ifdef REFLECTIONMAP_CUBIC
 	#ifdef USE_LOCAL_REFLECTIONMAP_CUBIC
 		//>> VRNET
-    	return computeCubicLocalCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix, uniforms.vReflectionSize, uniforms.vReflectionPosition, uniforms.vReflectionOffset, uniforms.vBoundingBoxMax, uniforms.vBoundingBoxMin, true);
+    	return computeCubicLocalCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix, uniforms.vReflectionSize, uniforms.vReflectionPosition, uniforms.vReflectionOffset, uniforms.vBoundingBoxMax, uniforms.vBoundingBoxMin, 1.0);
 		//<< VRNET
 	#else
     	return computeCubicCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix);

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
@@ -90,6 +90,26 @@ fn computeCubicLocalCoords(worldPos: vec4f, worldNormal: vec3f, eyePosition: vec
     return coords;
 }
 
+//>> VRNET
+fn computeBoundingBasedCoords(worldPos: vec4f, worldNormal: vec3f, eyePosition: vec3f, reflectionMatrix: mat4x4f, reflectionSize: vec3f, reflectionPosition: vec3f, reflectionOffset: vec3f, boundingBoxMax: vec3f, boundingBoxMin: vec3f) -> vec3f
+{
+    var viewDir: vec3f = normalize(worldPos.xyz - eyePosition);
+
+    // worldNormal has already been normalized.
+    var coords: vec3f = reflect(viewDir, worldNormal);
+
+	coords = boundingBasedReflection(worldPos.xyz, coords, reflectionSize, reflectionPosition, reflectionOffset, eyePosition, boundingBoxMax, boundingBoxMin);
+
+    coords = (reflectionMatrix *  vec4f(coords, 0)).xyz;
+
+    #ifdef INVERTCUBICMAP
+        coords.y *= -1.0;
+    #endif
+
+    return coords;
+}
+//<< VRNET
+
 fn computeProjectionCoords(worldPos: vec4f, view: mat4x4f, reflectionMatrix: mat4x4f) -> vec3f
 {
 	return (reflectionMatrix * (view * worldPos)).xyz;
@@ -127,7 +147,9 @@ fn computeReflectionCoords(worldPos: vec4f, worldNormal: vec3f) -> vec3f
 
 #ifdef REFLECTIONMAP_CUBIC
 	#ifdef USE_LOCAL_REFLECTIONMAP_CUBIC
-    	return computeCubicLocalCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix, uniforms.vReflectionSize, uniforms.vReflectionPosition);
+		//>> VRNET
+    	return computeBoundingBasedCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix, uniforms.vReflectionSize, uniforms.vReflectionPosition, uniforms.vReflectionOffset, uniforms.vBoundingBoxMax, uniforms.vBoundingBoxMin);
+		//<< VRNET
 	#else
     	return computeCubicCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix);
 	#endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
@@ -83,7 +83,7 @@ fn computeCubicLocalCoords(
 	reflectionOffset: vec3f, 
 	boundingBoxMax: vec3f, 
 	boundingBoxMin: vec3f, 
-	useBoundingBox: float
+	useBoundingBox: bool
 ) -> vec3f
 {
     var viewDir: vec3f = normalize(worldPos.xyz - eyePosition);
@@ -150,7 +150,7 @@ fn computeReflectionCoords(worldPos: vec4f, worldNormal: vec3f) -> vec3f
 #ifdef REFLECTIONMAP_CUBIC
 	#ifdef USE_LOCAL_REFLECTIONMAP_CUBIC
 		//>> VRNET
-    	return computeCubicLocalCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix, uniforms.vReflectionSize, uniforms.vReflectionPosition, uniforms.vReflectionOffset, uniforms.vBoundingBoxMax, uniforms.vBoundingBoxMin, 1.0);
+    	return computeCubicLocalCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix, uniforms.vReflectionSize, uniforms.vReflectionPosition, uniforms.vReflectionOffset, uniforms.vBoundingBoxMax, uniforms.vBoundingBoxMin, true);
 		//<< VRNET
 	#else
     	return computeCubicCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix);

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
@@ -98,7 +98,7 @@ fn computeBoundingBasedCoords(worldPos: vec4f, worldNormal: vec3f, eyePosition: 
     // worldNormal has already been normalized.
     var coords: vec3f = reflect(viewDir, worldNormal);
 
-	coords = boundingBasedReflection(worldPos.xyz, coords, reflectionSize, reflectionPosition, reflectionOffset, eyePosition, boundingBoxMax, boundingBoxMin);
+	coords = boundingBasedParallaxCorrectNormal(worldPos.xyz, coords, reflectionSize, reflectionPosition, reflectionOffset, boundingBoxMax, boundingBoxMin);
 
     coords = (reflectionMatrix *  vec4f(coords, 0)).xyz;
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/reflectionFunction.fx
@@ -72,33 +72,35 @@ fn computeCubicCoords(worldPos: vec4f, worldNormal: vec3f, eyePosition: vec3f, r
     return coords;
 }
 
-fn computeCubicLocalCoords(worldPos: vec4f, worldNormal: vec3f, eyePosition: vec3f, reflectionMatrix: mat4x4f, reflectionSize: vec3f, reflectionPosition: vec3f) -> vec3f
-{
-    var viewDir: vec3f = normalize(worldPos.xyz - eyePosition);
-
-    // worldNormal has already been normalized.
-    var coords: vec3f = reflect(viewDir, worldNormal);
-
-	coords = parallaxCorrectNormal(worldPos.xyz, coords, reflectionSize, reflectionPosition);
-
-    coords = (reflectionMatrix *  vec4f(coords, 0)).xyz;
-
-    #ifdef INVERTCUBICMAP
-        coords.y *= -1.0;
-    #endif
-
-    return coords;
-}
-
 //>> VRNET
-fn computeBoundingBasedCoords(worldPos: vec4f, worldNormal: vec3f, eyePosition: vec3f, reflectionMatrix: mat4x4f, reflectionSize: vec3f, reflectionPosition: vec3f, reflectionOffset: vec3f, boundingBoxMax: vec3f, boundingBoxMin: vec3f) -> vec3f
+fn computeCubicLocalCoords(
+	worldPos: vec4f, 
+	worldNormal: vec3f, 
+	eyePosition: vec3f, 
+	reflectionMatrix: mat4x4f, 
+	reflectionSize: vec3f, 
+	reflectionPosition: vec3f,
+	reflectionOffset: vec3f, 
+	boundingBoxMax: vec3f, 
+	boundingBoxMin: vec3f, 
+	useBoundingBox: bool
+) -> vec3f
 {
     var viewDir: vec3f = normalize(worldPos.xyz - eyePosition);
 
     // worldNormal has already been normalized.
     var coords: vec3f = reflect(viewDir, worldNormal);
 
-	coords = boundingBasedParallaxCorrectNormal(worldPos.xyz, coords, reflectionSize, reflectionPosition, reflectionOffset, boundingBoxMax, boundingBoxMin);
+	coords = parallaxCorrectNormal(
+		worldPos.xyz, 
+		coords, 
+		reflectionSize, 
+		reflectionPosition,
+		reflectionOffset, 
+		boundingBoxMax, 
+		boundingBoxMin, 
+		useBoundingBox
+	);
 
     coords = (reflectionMatrix *  vec4f(coords, 0)).xyz;
 
@@ -148,7 +150,7 @@ fn computeReflectionCoords(worldPos: vec4f, worldNormal: vec3f) -> vec3f
 #ifdef REFLECTIONMAP_CUBIC
 	#ifdef USE_LOCAL_REFLECTIONMAP_CUBIC
 		//>> VRNET
-    	return computeBoundingBasedCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix, uniforms.vReflectionSize, uniforms.vReflectionPosition, uniforms.vReflectionOffset, uniforms.vBoundingBoxMax, uniforms.vBoundingBoxMin);
+    	return computeCubicLocalCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix, uniforms.vReflectionSize, uniforms.vReflectionPosition, uniforms.vReflectionOffset, uniforms.vBoundingBoxMax, uniforms.vBoundingBoxMin, true);
 		//<< VRNET
 	#else
     	return computeCubicCoords(worldPos, worldNormal, scene.vEyePosition.xyz, uniforms.reflectionMatrix);

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -210,7 +210,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 	#ifdef REFRACTIONMAP_3D
         #ifdef USE_LOCAL_REFRACTIONMAP_CUBIC
 			//>> VRNET
-            refractionVector = parallaxCorrectNormal(fragmentInputs.vPositionW, refractionVector, uniforms.vRefractionSize, uniforms.vRefractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), 0.);
+            refractionVector = parallaxCorrectNormal(fragmentInputs.vPositionW, refractionVector, uniforms.vRefractionSize, uniforms.vRefractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), false);
 			//<< VRNET
         #endif
 		refractionVector.y = refractionVector.y * uniforms.vRefractionInfos.w;

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -209,7 +209,9 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 	var refractionVector: vec3f = normalize(refract(-viewDirectionW, normalW, uniforms.vRefractionInfos.y));
 	#ifdef REFRACTIONMAP_3D
         #ifdef USE_LOCAL_REFRACTIONMAP_CUBIC
-            refractionVector = parallaxCorrectNormal(fragmentInputs.vPositionW, refractionVector, uniforms.vRefractionSize, uniforms.vRefractionPosition);
+			//>> VRNET
+            refractionVector = parallaxCorrectNormal(fragmentInputs.vPositionW, refractionVector, uniforms.vRefractionSize, uniforms.vRefractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), false);
+			//<< VRNET
         #endif
 		refractionVector.y = refractionVector.y * uniforms.vRefractionInfos.w;
 

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -210,7 +210,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 	#ifdef REFRACTIONMAP_3D
         #ifdef USE_LOCAL_REFRACTIONMAP_CUBIC
 			//>> VRNET
-            refractionVector = parallaxCorrectNormal(fragmentInputs.vPositionW, refractionVector, uniforms.vRefractionSize, uniforms.vRefractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), false);
+            refractionVector = parallaxCorrectNormal(fragmentInputs.vPositionW, refractionVector, uniforms.vRefractionSize, uniforms.vRefractionPosition, vec3f(0.), vec3f(0.), vec3f(0.), 0.);
 			//<< VRNET
         #endif
 		refractionVector.y = refractionVector.y * uniforms.vRefractionInfos.w;

--- a/packages/dev/core/src/ShadersWGSL/screenSpaceReflection2.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/screenSpaceReflection2.fragment.fx
@@ -145,7 +145,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
     #ifdef SSR_USE_LOCAL_REFLECTIONMAP_CUBIC
         var worldPos: vec4f = uniforms.invView *  vec4f(csPosition, 1.0);
         //>> VRNET
-	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), uniforms.vReflectionSize, uniforms.vReflectionPosition, vec3f(0.), vec3f(0.), vec3f(0.), false);
+	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), uniforms.vReflectionSize, uniforms.vReflectionPosition, vec3f(0.), vec3f(0.), vec3f(0.), 0.);
         //<< VRNET
     #endif
     #ifdef SSR_INVERTCUBICMAP

--- a/packages/dev/core/src/ShadersWGSL/screenSpaceReflection2.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/screenSpaceReflection2.fragment.fx
@@ -144,7 +144,9 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
     var wReflectedVector: vec3f = (uniforms.invView *  vec4f(csReflectedVector, 0.0)).xyz;
     #ifdef SSR_USE_LOCAL_REFLECTIONMAP_CUBIC
         var worldPos: vec4f = uniforms.invView *  vec4f(csPosition, 1.0);
-	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), uniforms.vReflectionSize, uniforms.vReflectionPosition);
+        //>> VRNET
+	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), uniforms.vReflectionSize, uniforms.vReflectionPosition, vec3f(0.), vec3f(0.), vec3f(0.), false);
+        //<< VRNET
     #endif
     #ifdef SSR_INVERTCUBICMAP
         wReflectedVector.y *= -1.0;

--- a/packages/dev/core/src/ShadersWGSL/screenSpaceReflection2.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/screenSpaceReflection2.fragment.fx
@@ -145,7 +145,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
     #ifdef SSR_USE_LOCAL_REFLECTIONMAP_CUBIC
         var worldPos: vec4f = uniforms.invView *  vec4f(csPosition, 1.0);
         //>> VRNET
-	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), uniforms.vReflectionSize, uniforms.vReflectionPosition, vec3f(0.), vec3f(0.), vec3f(0.), 0.);
+	    wReflectedVector = parallaxCorrectNormal(worldPos.xyz, normalize(wReflectedVector), uniforms.vReflectionSize, uniforms.vReflectionPosition, vec3f(0.), vec3f(0.), vec3f(0.), false);
         //<< VRNET
     #endif
     #ifdef SSR_INVERTCUBICMAP


### PR DESCRIPTION
1. Для всіх непов'язаних шейдерів прибрав старий фікс `_reflectionOffsetName`, бо він ні разу не викликається (відповідний define не створювався), і це фактично зміна в код без перевірки, та й взагалі не має сенсу.
2.  Додав окрему функцію під розрахунок координат відбиття, яку викликаю замість старої там де треба і яка виправляє помилку, відкотив старі зміни у старій функції.
3. Впровадив межі bounding box'ів у шейдері для роботи цієї функції
4. Зробив аналогічну імплементацію із WGSL для майбутньої сумісності із WebGPU